### PR TITLE
floor(collection view cell width)

### DIFF
--- a/LEAmountInputView/LENumberPad.m
+++ b/LEAmountInputView/LENumberPad.m
@@ -120,7 +120,7 @@
     CGFloat interitemSpacing = collectionViewLayout.minimumInteritemSpacing * (((float)numberOfColumns - 1.0f) / (float)numberOfColumns);
     CGFloat lineSpacing = collectionViewLayout.minimumLineSpacing * (((float)numberOfRows - 1.0f) / (float)numberOfRows);
     
-    return (CGSize){width - interitemSpacing, height - lineSpacing};
+    return (CGSize){floor(width - interitemSpacing), height - lineSpacing};
 }
 
 #pragma mark - IBActions


### PR DESCRIPTION
floor(collection view cell width) needed
total sum of cells width and inter item spacing could be greater than width of superview and it will moving cells on the right side of collection view to next line

for example
if superview width = 202 and interitemSpacing = 1 then sum of cell widths + spacing will be 202.000015 > superview width

![simulator screen shot 24 2017 2 13 19](https://cloud.githubusercontent.com/assets/828018/22227673/7c30b028-e1dd-11e6-93e8-8be9d4147561.png)